### PR TITLE
clean: remove files linked from dictsource/extra

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,7 @@ AM_CFLAGS = \
 	-Wno-endif-labels
 
 EXTRA_DIST=
+CLEANFILES = dictsource/ru_listx dictsource/cmn_listx dictsource/yue_listx
 
 bin_PROGRAMS =
 lib_LTLIBRARIES =


### PR DESCRIPTION
The links persisted when ./configure run with extended dictionaries
disabled.